### PR TITLE
store allowed featuresets in an array to check against

### DIFF
--- a/adafruit_sgp30.py
+++ b/adafruit_sgp30.py
@@ -51,7 +51,8 @@ __repo__ = "https://github.com/alexmrqt/Adafruit_CircuitPython_SGP30.git"
 
 # pylint: disable=bad-whitespace
 _SGP30_DEFAULT_I2C_ADDR  = const(0x58)
-_SGP30_FEATURESET        = const(0x0020)
+_SGP30_FEATURESET_0      = const(0x0020)
+_SGP30_FEATURESET_1      = const(0x0022) 
 
 _SGP30_CRC8_POLYNOMIAL   = const(0x31)
 _SGP30_CRC8_INIT         = const(0xFF)
@@ -75,7 +76,7 @@ class Adafruit_SGP30:
         self.serial = self._i2c_read_words_from_cmd([0x36, 0x82], 0.01, 3)
         # get featuerset
         featureset = self._i2c_read_words_from_cmd([0x20, 0x2f], 0.01, 1)
-        if featureset[0] != _SGP30_FEATURESET:
+        if featureset[0] not in [ _SGP30_FEATURESET_0, _SGP30_FEATURESET_1 ]:
             raise RuntimeError('SGP30 Not detected')
         self.iaq_init()
 


### PR DESCRIPTION
In the meantime at least a featureset 0x0022 appeared, this patch allows initialization for boards with both known featuresets. I'll check out if further modifications might be needed and add pull requests accordingly.